### PR TITLE
Adds the ability to roll and zoom the camera in freecam mode

### DIFF
--- a/DivaHook/src/Components/CameraController.cpp
+++ b/DivaHook/src/Components/CameraController.cpp
@@ -26,8 +26,13 @@ namespace DivaHook::Components
 
 		delete UpBinding;
 		delete DownBinding;
+		delete ClockwiseBinding;
+		delete CounterClockwiseBinding;
+		delete ZoomInBinding;
+		delete ZoomOutBinding;
 		delete FastBinding;
 		delete SlowBinding;
+
 	}
 
 	const char* CameraController::GetDisplayName()
@@ -63,6 +68,16 @@ namespace DivaHook::Components
 		UpBinding->AddBinding(new KeyboardBinding(VK_SPACE));
 		DownBinding = new Binding();
 		DownBinding->AddBinding(new KeyboardBinding(VK_CONTROL));
+
+		ClockwiseBinding = new Binding();
+		ClockwiseBinding->AddBinding(new KeyboardBinding('E'));
+		CounterClockwiseBinding = new Binding();
+		CounterClockwiseBinding->AddBinding(new KeyboardBinding('Q'));
+
+		ZoomInBinding = new Binding();
+		ZoomInBinding->AddBinding(new KeyboardBinding('R'));
+		ZoomOutBinding = new Binding();
+		ZoomOutBinding->AddBinding(new KeyboardBinding('F'));
 
 		FastBinding = new Binding();
 		FastBinding->AddBinding(new KeyboardBinding(VK_SHIFT));
@@ -102,6 +117,12 @@ namespace DivaHook::Components
 		bool fast = FastBinding->AnyDown();
 		bool slow = SlowBinding->AnyDown();
 
+		bool clockwise = ClockwiseBinding->AnyDown();
+		bool counterclockwise = CounterClockwiseBinding->AnyDown();
+
+		bool zoomin = ZoomInBinding->AnyDown();
+		bool zoomout = ZoomOutBinding->AnyDown();
+
 		float speed = GetElapsedTime() * (fast ? fastSpeed : slow ? slowSpeed : normalSpeed);
 
 		if (forward ^ backward)
@@ -109,6 +130,12 @@ namespace DivaHook::Components
 
 		if (left ^ right)
 			camera->Position += PointFromAngle(verticalRotation + (right ? +90.0f : -90.0f), speed);
+
+		if(clockwise ^ counterclockwise)
+			camera->Rotation += speed * (clockwise ? -1.0f : +1.0f);
+
+		if(zoomin ^ zoomout)
+			camera->HorizontalFov += speed * (zoomin ? -1.0f : +1.0f);
 
 		if (up ^ down)
 			camera->Position.Y += speed * (up ? +0.25f : -0.25f);

--- a/DivaHook/src/Components/CameraController.h
+++ b/DivaHook/src/Components/CameraController.h
@@ -21,6 +21,12 @@ namespace DivaHook::Components
 		Input::Binding* FastBinding;
 		Input::Binding* SlowBinding;
 
+		Input::Binding* ClockwiseBinding;
+		Input::Binding* CounterClockwiseBinding;
+
+		Input::Binding* ZoomInBinding;
+		Input::Binding* ZoomOutBinding;
+
 		CameraController();
 		~CameraController();
 


### PR DESCRIPTION
Title. The freecam has quite a lot of potential to be fairly useful for screenshots. This PR adds the ability for the F3 camera to be rolled and zoomed with Q+E and R+F respectively.

Here's some example screenies of it in action
![diva_2019-03-07_03-06-02](https://user-images.githubusercontent.com/6356337/53942035-c0262a00-4087-11e9-9cff-061663936e73.jpg)
![diva_2019-03-07_03-02-27](https://user-images.githubusercontent.com/6356337/53942039-c4524780-4087-11e9-9435-143f363cf3ef.jpg)
![diva_2019-03-07_03-02-01](https://user-images.githubusercontent.com/6356337/53942550-1182e900-4089-11e9-8957-0c202910fd8c.jpg)

Q to roll counter-clockwise, E to roll clockwise. R to zoom in, F to zoom out. They're both affected by the alt and shift modifiers.

It'd be sick if it were plausible to pause a PV whilst retaining full control of the freecam, but that's out of this PR's scope.
