### PR TITLE
Adds 75Hz to framerate list and ability to change plate skin and player level

### DIFF
--- a/DivaHook/src/Components/FrameRateManager.cpp
+++ b/DivaHook/src/Components/FrameRateManager.cpp
@@ -38,6 +38,7 @@ namespace DivaHook::Components
 		float commonRefreshRates[]
 		{
 			60.0f,
+			75.0f,
 			120.0f,
 			144.0f,
 			240.0f,

--- a/DivaHook/src/Components/PlayerData.h
+++ b/DivaHook/src/Components/PlayerData.h
@@ -72,7 +72,7 @@ struct PlayerData
 	int32_t field_EC;
 	int32_t field_F0;
 	int32_t field_F4;
-	int32_t field_F8;
+	int32_t level;
 	int32_t level_plate_id;
 	int32_t field_100;
 	int32_t vocaloid_point;

--- a/DivaHook/src/Components/PlayerDataManager.cpp
+++ b/DivaHook/src/Components/PlayerDataManager.cpp
@@ -31,6 +31,8 @@ namespace DivaHook::Components
 
 	void PlayerDataManager::Update()
 	{
+		playerData->level = customPlayerData.LevelNo;
+		playerData->level_plate_id = customPlayerData.LevelPlateId;
 		playerData->skin_equip = customPlayerData.SkinEquip;
 		playerData->btn_se_equip = customPlayerData.BtnSeEquip;
 		playerData->vocaloid_point = customPlayerData.VocaloidPoint;
@@ -40,6 +42,8 @@ namespace DivaHook::Components
 
 		if (customPlayerData.PlayerName != nullptr)
 			playerData->player_name = (char*)customPlayerData.PlayerName->c_str();
+		if (customPlayerData.LevelName != nullptr)
+			playerData->level_name = (char*)customPlayerData.LevelName->c_str();
 
 		//if (Input::Keyboard::GetInstance()->IsTapped(VK_F12))
 		//{
@@ -56,9 +60,12 @@ namespace DivaHook::Components
 			return;
 
 		std::string *customName;
+		std::string *levelName;
 
 		if (config.TryGetValue("player_name", customName))
 			customPlayerData.PlayerName = customName;
+		if (config.TryGetValue("level_name", levelName))
+			customPlayerData.LevelName = levelName;
 
 		auto parseInt = [&](const std::string &key)
 		{
@@ -75,6 +82,8 @@ namespace DivaHook::Components
 			return result;
 		};
 
+		customPlayerData.LevelNo = parseInt("level");
+		customPlayerData.LevelPlateId = parseInt("level_plate_id");
 		customPlayerData.SkinEquip = parseInt("skin_equip");
 		customPlayerData.BtnSeEquip = parseInt("btn_se_equip");
 		customPlayerData.VocaloidPoint = parseInt("vocaloid_point");

--- a/DivaHook/src/Components/PlayerDataManager.h
+++ b/DivaHook/src/Components/PlayerDataManager.h
@@ -8,6 +8,9 @@ namespace DivaHook::Components
 	struct CustomPlayerData
 	{
 		std::string *PlayerName;
+		std::string *LevelName;
+		int LevelNo;
+		int LevelPlateId;
 		int SkinEquip;
 		int BtnSeEquip;
 		int VocaloidPoint;


### PR DESCRIPTION
Just some addition to satisfy people's needs of feeling more entitled and experienced despite playing such an outdated crappy dump.

Known issue is when `level_name` is set, it become an invalid entry and cannot be displayed. It's either the mapping is wrong or it check for the networking shit to verify the string or whatsoever.

Being so despair that I cannot think any good name for `field_F8` but that is exactly the level number of the player, so I leave all to you Sammy.